### PR TITLE
Add local IPv6 addresses

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "SIGHUP",
         "sndiod",
         "SNMP",
+        "steamdeck",
         "tailscale",
         "tailscaled",
         "vnetid",

--- a/etc/hostname.vlan2
+++ b/etc/hostname.vlan2
@@ -1,5 +1,6 @@
 parent vport1
 vnetid 2
 inet 10.2.0.1 255.255.255.0 10.2.0.255
+inet6 alias fd00:1020::1/64
 group guest_lan
 up

--- a/etc/hostname.vlan3
+++ b/etc/hostname.vlan3
@@ -1,5 +1,6 @@
 parent vport1
 vnetid 3
 inet 10.3.0.1 255.255.255.0 10.3.0.255
+inet6 alias fd00:1030::1/64
 group iot_lan
 up

--- a/etc/hostname.vlan4
+++ b/etc/hostname.vlan4
@@ -1,5 +1,6 @@
 parent vport1
 vnetid 4
 inet 10.4.0.1 255.255.255.0 10.4.0.255
+inet6 alias fd00:1040::1/64
 group work_lan
 up

--- a/etc/hostname.vport0
+++ b/etc/hostname.vport0
@@ -1,3 +1,4 @@
 inet 10.1.0.1 255.255.255.0 10.1.0.255
+inet6 alias fd00:1010::1/64
 group trusted_lan
 up

--- a/etc/hosts
+++ b/etc/hosts
@@ -2,3 +2,4 @@
 ::1		localhost
 
 10.1.0.1 router.lan.jwillikers.io router.jwillikers.io router
+fd00:1010::1 router.lan.jwillikers.io router.jwillikers.io router

--- a/etc/pf.conf
+++ b/etc/pf.conf
@@ -5,15 +5,20 @@ table <guest_lan_routers> { 10.2.0.1 }
 table <iot_lan_routers> { 10.3.0.1 }
 table <work_lan_routers> { 10.4.0.1 }
 
-trusted_lan_primary_dns_server = 10.1.0.1
-guest_lan_primary_dns_server = 10.2.0.1
-iot_lan_primary_dns_server = 10.3.0.1
-work_lan_primary_dns_server = 10.4.0.1
+trusted_lan_primary_dns_server_ipv4 = 10.1.0.1
+guest_lan_primary_dns_server_ipv4 = 10.2.0.1
+iot_lan_primary_dns_server_ipv4 = 10.3.0.1
+work_lan_primary_dns_server_ipv4 = 10.4.0.1
 
-table <trusted_lan_dns_servers> { 10.1.0.1 }
-table <guest_lan_dns_servers> { 10.2.0.1 }
-table <iot_lan_dns_servers> { 10.3.0.1 }
-table <work_lan_dns_servers> { 10.4.0.1 }
+trusted_lan_primary_dns_server_ipv6 = fd00:1010::1
+guest_lan_primary_dns_server_ipv6 = fd00:1020::1
+iot_lan_primary_dns_server_ipv6 = fd00:1030::1
+work_lan_primary_dns_server_ipv6 = fd00:1040::1
+
+table <trusted_lan_dns_servers> { 10.1.0.1 fd00:1010::1/128 }
+table <guest_lan_dns_servers> { 10.2.0.1 fd00:1020::1/128 }
+table <iot_lan_dns_servers> { 10.3.0.1 fd00:1030::1/128 }
+table <work_lan_dns_servers> { 10.4.0.1 fd00:1040::1/128 }
 
 # ESPHome, Home Assistant, InfluxDB, and MQTT
 table <iot_servers> { 10.1.0.40 10.1.0.47 }
@@ -25,7 +30,7 @@ table <martians> { 0.0.0.0/8 127.0.0.0/8 169.254.0.0/16 172.16.0.0/12 192.0.0.0/
                    192.168.0.0/16 198.18.0.0/15 198.51.100.0/24 203.0.113.0/24 \
                    ::/128 ::/96 ::1/128 ::ffff:0:0/96 100::/64 2001:10::/28 2001:2::/48 2001:db8::/32 3ffe::/16 fec0::/10 fc00::/7 }
 
-table <google_dns_servers> { 8.8.8.8 8.8.4.4 }
+table <google_dns_servers> { 8.8.8.8 8.8.4.4 2001:4860:4860::8888/128 2001:4860:4860::8844/128 }
 
 table <tailscale_vpn_dns_servers> { 100.127.231.23 fd7a:115c:a1e0:ab12:4843:cd96:627f:e717 }
 
@@ -101,10 +106,15 @@ pass on { iot_lan trusted_lan } from iot_lan:network to { <iot_servers> <monitor
 pass on { iot_lan trusted_lan } from { <iot_servers> <monitoring_servers> } to iot_lan:network
 
 # Redirect DNS traffic
-pass in on trusted_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $trusted_lan_primary_dns_server port domain
-pass in on guest_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $guest_lan_primary_dns_server port domain
-pass in on iot_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $iot_lan_primary_dns_server port domain
-pass in on work_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $work_lan_primary_dns_server port domain
+pass in on trusted_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $trusted_lan_primary_dns_server_ipv4 port domain
+pass in on guest_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $guest_lan_primary_dns_server_ipv4 port domain
+pass in on iot_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $iot_lan_primary_dns_server_ipv4 port domain
+pass in on work_lan inet proto { tcp udp } to <google_dns_servers> port domain divert-to $work_lan_primary_dns_server_ipv4 port domain
+
+pass in on trusted_lan inet6 proto { tcp udp } to <google_dns_servers> port domain divert-to $trusted_lan_primary_dns_server_ipv6 port domain
+pass in on guest_lan inet6 proto { tcp udp } to <google_dns_servers> port domain divert-to $guest_lan_primary_dns_server_ipv6 port domain
+pass in on iot_lan inet6 proto { tcp udp } to <google_dns_servers> port domain divert-to $iot_lan_primary_dns_server_ipv6 port domain
+pass in on work_lan inet6 proto { tcp udp } to <google_dns_servers> port domain divert-to $work_lan_primary_dns_server_ipv6 port domain
 
 # Allow multicast networking
 pass on { iot_lan trusted_lan } proto igmp all allow-opts

--- a/etc/rad.conf
+++ b/etc/rad.conf
@@ -1,4 +1,35 @@
-interface vport0
-interface vlan2
-interface vlan3
-interface vlan4
+dns {
+  search {
+    jwillikers.io
+    lan.jwillikers.io
+  }
+}
+
+interface vport0 {
+  dns {
+    nameserver {
+      fd00:1010::1
+    }
+  }
+}
+interface vlan2 {
+  dns {
+    nameserver {
+      fd00:1020::1
+    }
+  }
+}
+interface vlan3 {
+  dns {
+    nameserver {
+      fd00:1030::1
+    }
+  }
+}
+interface vlan4 {
+  dns {
+    nameserver {
+      fd00:1040::1
+    }
+  }
+}

--- a/etc/snmpd.conf.template
+++ b/etc/snmpd.conf.template
@@ -1,14 +1,22 @@
-vport0_addr="10.1.0.1"
-vlan2_addr="10.2.0.1"
-vlan3_addr="10.3.0.1"
-vlan4_addr="10.4.0.1"
+vport0_ipv4_addr="10.1.0.1"
+vlan2_ipv4_addr="10.2.0.1"
+vlan3_ipv4_addr="10.3.0.1"
+vlan4_ipv4_addr="10.4.0.1"
+vport0_ipv6_addr="fd00:1010::1"
+vlan2_ipv6_addr="fd00:1020::1"
+vlan3_ipv6_addr="fd00:1030::1"
+vlan4_ipv6_addr="fd00:1040::1"
 tailscale_ipv4_addr="100.127.231.23"
 tailscale_ipv6_addr="fd7a:115c:a1e0:ab12:4843:cd96:627f:e717"
 
-listen on udp $vport0_addr read
-listen on udp $vlan2_addr read
-listen on udp $vlan3_addr read
-listen on udp $vlan4_addr read
+listen on udp $vport0_ipv4_addr read
+listen on udp $vlan2_ipv4_addr read
+listen on udp $vlan3_ipv4_addr read
+listen on udp $vlan4_ipv4_addr read
+listen on udp $vport0_ipv6_addr read
+listen on udp $vlan2_ipv6_addr read
+listen on udp $vlan3_ipv6_addr read
+listen on udp $vlan4_ipv6_addr read
 listen on udp $tailscale_ipv4_addr read
 listen on udp $tailscale_ipv6_addr read
 

--- a/etc/ssh/sshd_config.d/local_listen_address.conf
+++ b/etc/ssh/sshd_config.d/local_listen_address.conf
@@ -1,2 +1,4 @@
 ListenAddress 10.1.0.1
+ListenAddress [fd00:1010::1]
 ListenAddress 10.3.0.1
+ListenAddress [fd00:1030::1]

--- a/var/unbound/etc/unbound.conf
+++ b/var/unbound/etc/unbound.conf
@@ -21,7 +21,7 @@ server:
 	ip-transparent: yes
 
 	do-ip6: yes
-	#prefer-ip6: yes
+	prefer-ip6: yes
 
 	# Tailscale VPN endpoints
 	access-control: fc00::/7 allow

--- a/var/unbound/etc/unbound.conf
+++ b/var/unbound/etc/unbound.conf
@@ -6,6 +6,11 @@ server:
 	interface: 10.3.0.1
 	interface: 10.4.0.1
 
+	interface: fd00:1010::1
+	interface: fd00:1020::1
+	interface: fd00:1030::1
+	interface: fd00:1040::1
+
 	# Tailscale IPv4 and IPv6 addresses.
 	interface: fd7a:115c:a1e0:ab12:4843:cd96:627f:e717
 	interface: 100.127.231.23


### PR DESCRIPTION
This should be the last step to having full IPv6 support on the router. Local interfaces now have IPv6 addresses and provide services such as DNS and SNMP on these interfaces.